### PR TITLE
Show better errors with hunit helpers

### DIFF
--- a/src/Test/Predicates/HUnit.hs
+++ b/src/Test/Predicates/HUnit.hs
@@ -1,17 +1,15 @@
 -- | HUnit and Hspec integration for 'Predicate'
 module Test.Predicates.HUnit (assertSatisfied, (@?~), shouldSatisfy) where
 
-import Test.HUnit (Assertion, assertFailure)
-import Test.Predicates (Predicate (accept, explain))
+import GHC.Stack (HasCallStack, withFrozenCallStack)
+import Test.HUnit (Assertion)
+import Test.Predicates (Predicate, acceptIO)
 
-assertSatisfied :: Predicate a -> a -> Assertion
-assertSatisfied predicate val =
-  if accept predicate val
-    then return ()
-    else assertFailure (explain predicate val)
+assertSatisfied :: HasCallStack => Predicate a -> a -> Assertion
+assertSatisfied = withFrozenCallStack acceptIO
 
-(@?~) :: a -> Predicate a -> Assertion
-(@?~) = flip assertSatisfied
+(@?~) :: HasCallStack => a -> Predicate a -> Assertion
+(@?~) = flip (withFrozenCallStack acceptIO)
 
-shouldSatisfy :: a -> Predicate a -> Assertion
-shouldSatisfy = flip assertSatisfied
+shouldSatisfy :: HasCallStack => a -> Predicate a -> Assertion
+shouldSatisfy = flip (withFrozenCallStack acceptIO)


### PR DESCRIPTION
Currently, failures in `tasty-hunit` tests are shown as:
```
Exception: HUnitFailure (Just (SrcLoc {srcLocPackage = "explainable-predicates-0.1.2.1-5Ryn4YOYJRRKOINZgaXGtY", srcLocModule = "Test.Predicates.HUnit", srcLocFile = "src/Test/Predicates/HUnit.hs", srcLocStartLine = 11, srcLocStartCol = 10, srcLocEndLine = 11, srcLocEndCol = 47})) (Reason "all elements in a property: \8800 \"\\8226 constant is 42\"")
```
This adds a verbose callstack pointing to `explainable-predicates` instead of the actual test, and unicode characters are escaped. With this change, errors now look like:
```
Exception: all elements strip: ≠ "\8226 constant is 42"
CallStack (from HasCallStack):
  @?~, called at MyTest.hs:1:1 in main:MyTest
```
Note the callstack now shows where `@?~` was called in the user's code, and the error shows the unicode `≠` character.