### PR TITLE
Fix haddock for quickcheck

### DIFF
--- a/src/Test/Predicates/QuickCheck.hs
+++ b/src/Test/Predicates/QuickCheck.hs
@@ -13,7 +13,7 @@ import Test.QuickCheck (Property, counterexample)
 -- | QuickCheck property that checks if a predicate is satisfied.
 --
 -- @
---   quickCheck $ \(Positive x) -> [0 .. x] 'satisfies' (containsAll [eq 1, eq 2])
+--   quickCheck $ \\(Positive x) -> [0 .. x] \`satisfies\` (containsAll [eq 1, eq 2])
 -- @
 --
 -- @


### PR DESCRIPTION
Currently, haddocks show
```
quickCheck $ (Positive x) -> [0 .. x] satisfies (containsAll [eq 1, eq 2])
```
With this PR, it's now:
```
 quickCheck $ \(Positive x) -> [0 .. x] `satisfies` (containsAll [eq 1, eq 2])
```