### PR TITLE
Increase QuickCheck upper bound to allow 2.16

### DIFF
--- a/explainable-predicates.cabal
+++ b/explainable-predicates.cabal
@@ -72,7 +72,7 @@ library
         cpp-options:     -DCONTAINERS
 
     if flag(quickcheck)
-        build-depends:   QuickCheck >= 2.8 && < 2.15,
+        build-depends:   QuickCheck >= 2.8 && < 2.17,
         exposed-modules: Test.Predicates.QuickCheck
 
     if flag(hunit)


### PR DESCRIPTION
This builds and passes the test suite with Quickcheck 2.16.0.0.